### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -34,6 +36,9 @@ jobs:
   build-and-release:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/ModusCreate-Perdigao-GHAS-Playground/codeql-wrapper/security/code-scanning/4](https://github.com/ModusCreate-Perdigao-GHAS-Playground/codeql-wrapper/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimum permissions required for each job. For the `test` job, only `contents: read` is needed to check out the code and run tests. For the `build-and-release` job, additional permissions like `contents: write` and `packages: write` are required to create tags, push them to the repository, and publish to PyPI. These permissions will be added at the job level to ensure each job has only the permissions it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
