### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/ModusCreate-Perdigao-GHAS-Playground/codeql-wrapper/security/code-scanning/3](https://github.com/ModusCreate-Perdigao-GHAS-Playground/codeql-wrapper/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. Since the workflow primarily involves reading repository contents and running tests, the `contents: read` permission is sufficient. This block can be added at the root of the workflow to apply to all jobs or within the `test` job to limit its scope. For simplicity and clarity, we will add it at the root level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
