### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ModusCreate-Perdigao-GHAS-Playground/codeql-wrapper/security/code-scanning/1](https://github.com/ModusCreate-Perdigao-GHAS-Playground/codeql-wrapper/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly set the permissions required for the workflow to function. Since the workflow does not interact with GitHub resources, the minimal permissions of `contents: read` are sufficient. This change ensures that the workflow does not inadvertently inherit overly permissive default permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
