### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
   validate:
     name: Validate Release Input
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.validate.outputs.version }}
       is_prerelease: ${{ steps.validate.outputs.is_prerelease }}


### PR DESCRIPTION
Potential fix for [https://github.com/ModusCreate-Perdigao-GHAS-Playground/codeql-wrapper/security/code-scanning/16](https://github.com/ModusCreate-Perdigao-GHAS-Playground/codeql-wrapper/security/code-scanning/16)

To resolve this issue, add an explicit `permissions` block to the `validate` job in the workflow file. The block should grant only the permissions required for the job to function. Since the `validate` job does not perform any write operations or interact with repository contents, the minimal permission of `contents: read` should suffice. This change will limit the scope of the `GITHUB_TOKEN` to only read repository contents, adhering to security best practices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
